### PR TITLE
feat: add build step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - run: pnpm install --frozen-lockfile
+      
+      - name: Build package
+        run: pnpm build
 
       - name: Release with semantic-release
         run: pnpm release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,7 +22,8 @@
                 "assets": [
                     "CHANGELOG.md",
                     "package.json",
-                    "pnpm-lock.yaml"
+                    "pnpm-lock.yaml",
+                    "dist/**"
                 ],
                 "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
             }


### PR DESCRIPTION
This pull request improves the release workflow by ensuring that built package files are included in the release and that the build step is run before publishing. These changes help guarantee that the latest compiled code is available in every release.

Release workflow improvements:

* Added a `pnpm build` step to the release workflow in `.github/workflows/release.yml`, ensuring the package is built before releasing.
* Updated `.releaserc.json` to include the `dist/**` directory as a release asset, so built files are published with each release.