### PR TITLE
fix: remove 'dist/**' from release assets in .releaserc.json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,8 +22,7 @@
                 "assets": [
                     "CHANGELOG.md",
                     "package.json",
-                    "pnpm-lock.yaml",
-                    "dist/**"
+                    "pnpm-lock.yaml"
                 ],
                 "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
             }


### PR DESCRIPTION
This pull request makes a small update to the release configuration. The change removes the `dist/**` asset from the list of files included in releases in `.releaserc.json`.