### PR TITLE
fix: replace APIError with UseSendError for consistent error handling

### DIFF
--- a/src/email-usesend.spec.ts
+++ b/src/email-usesend.spec.ts
@@ -13,7 +13,7 @@ describe('email-useSend', () => {
   const subject = 'This was sent on init'
   const text = 'This is my message body'
 
-  const mockPayload = {} as unknown as Payload
+  const mockPayload = {} as Payload
 
   afterEach(() => {
     jest.clearAllMocks()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { APIError, type SendEmailOptions } from 'payload'
+import { type SendEmailOptions } from 'payload'
 
 import {
   type useSendAdapterArgs,
@@ -61,7 +61,7 @@ export const sendAdapter = (args: useSendAdapterArgs): useSendEmailAdapter => {
           formattedError += ` ${data.error.code} - ${data.error.message}`
         }
 
-        throw new APIError(formattedError, statusCode)
+        throw new UseSendError(formattedError, statusCode)
       }
     },
   })
@@ -92,7 +92,7 @@ function mapPayloadToUseSendEmail(
 
   if (message.attachments?.length) {
     if (message.attachments.length > 10) {
-      throw new APIError('Maximum of 10 attachments allowed', 400)
+      throw new UseSendError('Maximum of 10 attachments allowed', 400)
     }
     emailOptions.attachments = mapAttachments(message.attachments)
   }
@@ -152,12 +152,12 @@ function mapAttachments(
   }
 
   if (attachments.length > 10) {
-    throw new APIError('Maximum of 10 attachments allowed', 400)
+    throw new UseSendError('Maximum of 10 attachments allowed', 400)
   }
 
   return attachments.map((attachment) => {
     if (!attachment.filename || !attachment.content) {
-      throw new APIError('Attachment is missing filename or content', 400)
+      throw new UseSendError('Attachment is missing filename or content', 400)
     }
 
     if (typeof attachment.content === 'string') {
@@ -174,6 +174,15 @@ function mapAttachments(
       }
     }
 
-    throw new APIError('Attachment content must be a string or a buffer', 400)
+    throw new UseSendError('Attachment content must be a string or a buffer', 400)
   })
+}
+
+class UseSendError extends Error {
+  status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.status = status
+  }
 }


### PR DESCRIPTION
This pull request refactors error handling in the email sending logic to use a new custom error class, `UseSendError`, instead of the generic `APIError`. This change improves error specificity and decouples the module from external dependencies. Additionally, a minor type assertion improvement is made in the test file.

Error handling improvements:

* Introduced a new `UseSendError` class to replace all instances where `APIError` was previously thrown, providing clearer and more module-specific error reporting. (`src/index.ts`)
* Updated all error throws in email sending and attachment mapping logic to use `UseSendError` instead of `APIError`, including for attachment limits and validation errors. (`src/index.ts`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L64-R64) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L95-R95) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L155-R160) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L177-R188)

Dependency cleanup:

* Removed the import of `APIError` from `payload`, as it is no longer used. (`src/index.ts`)

Testing improvement:

* Simplified the type assertion for `mockPayload` in the test file. (`src/email-usesend.spec.ts`)